### PR TITLE
add   "doctrine/dbal": "~2.3" to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,9 @@
         "mockery/mockery": "0.8.*",
         "illuminate/support": "~4",
         "illuminate/console": "~4",
-        "illuminate/filesystem": "~4"
-    },
+        "illuminate/filesystem": "~4",
+        "doctrine/dbal": "~2.3"
+   },
     "autoload": {
         "psr-0": {
             "Dollar\\Generators": "src/"


### PR DESCRIPTION
doctrine/dbal is a suggest dependency for laravel/framework but it is required by the FormDumperGenerator. 

I am new to Laravel. I replaced way/generators with dollar/generators and found FileDumperGenerator blows up because Doctrine\DBAL\Driver\PDOMySql\Driver is unresolved when I try to dump the form.

I'm guessing adding it to require-dev is the right solution.